### PR TITLE
Replace service prefix with FQDN style prefix

### DIFF
--- a/registry/kubernetes/kubernetes.go
+++ b/registry/kubernetes/kubernetes.go
@@ -23,7 +23,7 @@ type kregistry struct {
 var (
 	// used on pods as labels & services to select
 	// eg: svcSelectorPrefix+"svc.name"
-	servicePrefix = "service.micro.mu/"
+	servicePrefix = "go.micro/"
 	serviceValue  = "service"
 
 	labelTypeKey   = "micro"
@@ -31,7 +31,7 @@ var (
 
 	// used on k8s services to scope a serialised
 	// micro service by pod name
-	annotationPrefix = "service.micro.mu/"
+	annotationPrefix = "go.micro/"
 
 	// Pod status
 	podRunning = "Running"

--- a/registry/kubernetes/kubernetes.go
+++ b/registry/kubernetes/kubernetes.go
@@ -23,7 +23,7 @@ type kregistry struct {
 var (
 	// used on pods as labels & services to select
 	// eg: svcSelectorPrefix+"svc.name"
-	servicePrefix = "micro/service/"
+	servicePrefix = "service.micro.mu/"
 	serviceValue  = "service"
 
 	labelTypeKey   = "micro"
@@ -31,7 +31,7 @@ var (
 
 	// used on k8s services to scope a serialised
 	// micro service by pod name
-	annotationPrefix = "micro/service/"
+	annotationPrefix = "service.micro.mu/"
 
 	// Pod status
 	podRunning = "Running"


### PR DESCRIPTION
According to the k8s documentation, the label and annotation prefixes should be in the format of a FQDN, with dot separated labels of no more than 63 characters. The current label and annotation paramteres are rejected by the k8s api, most likely because they have two forward slashes in them.